### PR TITLE
MHOUSE-867: Support correct BSON marshaling for ORC types

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -4,6 +4,10 @@ import (
 	"io"
 	"math"
 	"math/big"
+
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 // Decimal is a decimal type.
@@ -37,6 +41,16 @@ func (d Decimal) Float32() float32 {
 	f.SetFrac(d.Int, scaleToDenominator(d.Scale))
 	fl, _ := f.Float32()
 	return fl
+}
+
+// MarshalBSONValue implements the bson.ValueMarshaler interface.
+func (d Decimal) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	d128, err := primitive.ParseDecimal128(d.String())
+	if err != nil {
+		return bsontype.Decimal128, nil, err
+	}
+
+	return bsontype.Decimal128, bsoncore.AppendDecimal128(nil, d128), nil
 }
 
 // MarshalJSON implements the json.Marshaller interface.

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"math/big"
 	"testing"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 )
 
 func TestDecimal(t *testing.T) {
@@ -28,4 +30,18 @@ func TestDecimal(t *testing.T) {
 		t.Errorf("Test failed, expected %s got %s", expected, byt)
 	}
 
+}
+
+func TestDecimalMarshalBSONValue(t *testing.T) {
+	d := Decimal{big.NewInt(-8361232), 4}
+	btype, byt, err := d.MarshalBSONValue()
+	if err != nil {
+		t.Errorf("Test failed, expected no error but got %v", err)
+	}
+
+	expected := "{\"$numberDecimal\":\"-836.1232\"}"
+	actual := bsoncore.Value{Type: btype, Data: byt}.String()
+	if expected != actual {
+		t.Errorf("Test failed, expected %s but got %s", expected, actual)
+	}
 }

--- a/treereader_test.go
+++ b/treereader_test.go
@@ -1,0 +1,45 @@
+package orc
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+func TestMapEntryMarshalBSON(t *testing.T) {
+	t.Run("invalid MapEntry struct, non-string keys", func(t *testing.T) {
+		entry := MapEntry{Key: 1, Value: "apple"}
+		_, err := entry.MarshalBSON()
+		if err == nil {
+			t.Errorf("expected error, but got nil")
+		}
+	})
+
+	t.Run("valid MapEntry struct", func(t *testing.T) {
+		entry := MapEntry{Key: "b", Value: "banana"}
+		byt, err := entry.MarshalBSON()
+		if err != nil {
+			t.Errorf("expected no error, but got %v", err)
+		}
+
+		expected := "{\"b\": \"banana\"}"
+		actual := bsoncore.Document(byt).String()
+		if expected != actual {
+			t.Errorf("expected %s, but got %s", expected, actual)
+		}
+	})
+}
+
+func TestUnionValueMarshalBSONValue(t *testing.T) {
+	val := UnionValue{Tag: 0, Value: "apple"}
+	btype, byt, err := val.MarshalBSONValue()
+	if err != nil {
+		t.Errorf("expected no error, but got %v", err)
+	}
+
+	expected := "\"apple\""
+	actual := bsoncore.Value{Type: btype, Data: byt}.String()
+	if expected != actual {
+		t.Errorf("expected %s, but got %s", expected, actual)
+	}
+}

--- a/treereaderfactory.go
+++ b/treereaderfactory.go
@@ -25,7 +25,13 @@ func createTreeReader(schema *TypeDescription, s *Stripe) (TreeReader, error) {
 			s.get(streamName{id, proto.Stream_DATA}),
 			encoding,
 		)
-	case CategoryShort, CategoryInt, CategoryLong:
+	case CategoryShort, CategoryInt:
+		return NewInt32TreeReader(
+			s.get(streamName{id, proto.Stream_PRESENT}),
+			s.get(streamName{id, proto.Stream_DATA}),
+			encoding,
+		)
+	case CategoryLong:
 		return NewIntegerTreeReader(
 			s.get(streamName{id, proto.Stream_PRESENT}),
 			s.get(streamName{id, proto.Stream_DATA}),


### PR DESCRIPTION
Implements the `bson.Marshaler` or `bson.ValueMarshaler` interfaces for the ORC decimal, union, and map types so that they are marshaled into their correct BSON types. For example, decimal types are now represented as `{"$numberDecimal": XXX }` instead of being represented as the `{ int: {XXX}, scale: XXX }` structs that the `TreeReader` for these types return.

Also created a new `Int32TreeReader` that wraps the existing `IntegerTreeReader`. This new reader is for integers that can be represented as int32 values instead of int64 values (everything except long integers). This should allow short and int values to be marshaled into the `$numberInt` BSON value instead of `$numberLong`.